### PR TITLE
Make default home directory configurable; fix pointer handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ required):
    $ /usr/sbin/globus-gridftp-server -S -d ALL -c $WRKDIR/gridftp.conf
 
 
+Additional configuration
+--------------------------------
+1) If desired, change the default home directory by setting the homeDirPattern
+   environment variable in '/etc/gridftp.conf'.  The pattern can reference up to
+   two strings with '%s', first gets substituted with the zone name, second with
+   the user name.  The default value is "/%s/home/%s", making the default
+   directory '/<zone>/home/<username>'.  
+
+Default configuration:
+
+       $homeDirPattern "/%s/home/%s"
+
+Example alternative configuration (defaulting to '/<zone>/home'):
+
+       $homeDirPattern "/%s/home"
+
 
 Logrotate
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -170,16 +170,16 @@ required):
 Additional configuration
 --------------------------------
 1) If desired, change the default home directory by setting the homeDirPattern
-   environment variable in '/etc/gridftp.conf'.  The pattern can reference up to
-   two strings with '%s', first gets substituted with the zone name, second with
-   the user name.  The default value is "/%s/home/%s", making the default
-   directory '/<zone>/home/<username>'.  
+   environment variable in ````/etc/gridftp.conf````.  The pattern can reference up to
+   two strings with ````%s````, first gets substituted with the zone name, second with
+   the user name.  The default value is ````"/%s/home/%s"````, making the default
+   directory ````/<zone>/home/<username>````.
 
 Default configuration:
 
        $homeDirPattern "/%s/home/%s"
 
-Example alternative configuration (defaulting to '/<zone>/home'):
+Example alternative configuration (defaulting to ````/<zone>/home````):
 
        $homeDirPattern "/%s/home"
 

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -584,12 +584,11 @@ globus_l_gfs_iRODS_start(
 
     globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: connected.\n");
 
-    free(user_name);
+
+
+
     finished_info.info.session.home_dir = globus_common_create_string("/%s/home/%s", iRODS_handle->zone, user_name);
-    
-    /*If the home dir is composed by zone + user name, free user_name after 
-      setting finished_info.info.session.home_dir: move "free(user_name);" 
-      after whis comment. */
+    free(user_name);
 
     globus_gridftp_server_operation_finished(op, GLOBUS_SUCCESS, &finished_info);
     globus_free(finished_info.info.session.home_dir);

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -36,6 +36,16 @@
   #define IRODS_MAPS_PATH = ""
 #endif
 
+#ifndef DEFAULT_HOMEDIR_PATTERN
+  /* Default homeDir pattern, referencing up to two strings with %s.
+   * If used, first gets substituted with the zone name, second with the user name.
+   */
+  #define DEFAULT_HOMEDIR_PATTERN "/%s/home/%s"
+#endif
+
+/* name of environment variable to check for the homeDirPattern */
+#define HOMEDIR_PATTERN "homeDirPattern"
+
 static int                              iRODS_l_dev_wrapper = 10;
 struct iRODS_Resource
 {
@@ -515,6 +525,7 @@ globus_l_gfs_iRODS_start(
 
     rodsEnv myRodsEnv;
     char *user_name;
+    char *homeDirPattern;
     int status;
     rErrMsg_t errMsg;
 
@@ -584,10 +595,9 @@ globus_l_gfs_iRODS_start(
 
     globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: connected.\n");
 
-
-
-
-    finished_info.info.session.home_dir = globus_common_create_string("/%s/home/%s", iRODS_handle->zone, user_name);
+    homeDirPattern = getenv(HOMEDIR_PATTERN);
+    if (homeDirPattern == NULL) { homeDirPattern = DEFAULT_HOMEDIR_PATTERN; }
+    finished_info.info.session.home_dir = globus_common_create_string(homeDirPattern, iRODS_handle->zone, user_name);
     free(user_name);
 
     globus_gridftp_server_operation_finished(op, GLOBUS_SUCCESS, &finished_info);


### PR DESCRIPTION
Hi Roberto,

As discussed in #2, I have re-applied the fix to the pointer handling and made the default home directory configurable through the environment variable homeDirPattern, with the default being ````"/%s/home%s"````.

I've also updated the documentation (README.md) accordingly.

Please let me know whether you're happy to merge this in.

Cheers,
Vlad
