### PR TITLE
Fixes to directory listings

### DIFF
--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -287,7 +287,7 @@ iRODS_l_stat1(
             stat_out->ctime = realTime;
             stat_out->mtime = realTime;
             stat_out->atime = realTime;
-            stat_out->dev = iRODS_l_dev_wrapper;
+            stat_out->dev = iRODS_l_dev_wrapper++;
             stat_out->ino = iRODS_l_filename_hash(start_dir);
             stat_out->mode = S_IFREG | S_IRUSR | S_IWUSR |
                 S_IXUSR | S_IROTH | S_IXOTH | S_IRGRP | S_IXGRP;
@@ -395,7 +395,7 @@ iRODS_l_stat_dir(
 	    	stat_array[stat_ndx].ctime = realTime;
     	  	stat_array[stat_ndx].mtime = realTime;
         	stat_array[stat_ndx].atime = realTime;
-            stat_array[stat_ndx].dev = iRODS_l_dev_wrapper;
+            stat_array[stat_ndx].dev = iRODS_l_dev_wrapper++;
             stat_array[stat_ndx].ino = iRODS_l_filename_hash(collEnt.dataName);
             stat_array[stat_ndx].mode = S_IFREG | S_IRUSR | S_IWUSR |
                 S_IXUSR | S_IROTH | S_IXOTH | S_IRGRP | S_IXGRP;

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -389,6 +389,11 @@ iRODS_l_stat_dir(
             stat_array[stat_ndx].uid = getuid();
             stat_array[stat_ndx].gid = getgid();
             stat_array[stat_ndx].size = 0;
+
+            time_t realTime = atol(collEnt.modifyTime);
+            stat_array[stat_ndx].ctime = realTime;
+            stat_array[stat_ndx].mtime = realTime;
+
             stat_array[stat_ndx].dev = iRODS_l_dev_wrapper++;
             stat_array[stat_ndx].mode = S_IFDIR | S_IRUSR | S_IWUSR | 
                 S_IXUSR | S_IROTH | S_IXOTH | S_IRGRP | S_IXGRP;


### PR DESCRIPTION
Hi Roberto,

I've done a bit more work on how this module does directory listings.

We use multiple replicas in our iRODS server - and the module was returning multiple entries for the same object - one for each replica.

* I've applied the same fix as what Jargon does in ````CollectionAndDataObjectListAndSearchAOImpl.buildDataObjectListingWithAccessInfoFromResultSet```` : remember the last name seen, and only process the entry as a new file if it is different from the last name seen.

* I've made the listings for directories/collections show the correct timestamp (extract from the information returned by iRODS).

* I've added "." and ".." entries into the directory listings (for all but / folder) - details in the commit message.

* I've noticed iRODS_l_dev_wrapper was incremented only when getting a value for a directory but not for a file.  Assuming this was an oversight, changing the code to always increment the value...

Please let me know whether you're happy to merge these changes.

Cheers,
Vlad
