### PR TITLE
Native iRODS user mapping - gridmap callout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cmake_install.cmake
 install_manifest.txt
 *.so
 *.so.*
+.cproject
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ cmake_install.cmake
 install_manifest.txt
 *.so
 *.so.*
+testirodsmap
+gridmap_iRODS_callout.conf
 .cproject
 .project

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+install_manifest.txt
+*.so
+*.so.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,23 +47,55 @@ endif()
 if (DEFINED ENV{FLAVOR})
     message("FLAVOR is defined as $ENV{FLAVOR}")
     set(dsi_library_name globus_gridftp_server_iRODS_$ENV{FLAVOR})
+    set(gridmap_callout_library_name gridmap_iRODS_callout_$ENV{FLAVOR})
+    set(gridmap_callout_library_LINK_FLAGS "-lglobus_gridmap_callout_error_$ENV{FLAVOR}")
 else()
     message( WARNING "FLAVOR is NOT defined!" )
     set(dsi_library_name globus_gridftp_server_iRODS)
+    set(gridmap_callout_library_name gridmap_iRODS_callout)
+    set(gridmap_callout_library_LINK_FLAGS "-lglobus_gridmap_callout_error")
 endif()
 
 if (NOT DEFINED ENV{DEST_LIB_DIR})
     set(ENV{DEST_LIB_DIR} "$ENV{GLOBUS_LOCATION}/lib")
+    # Note: this may have to be lib64 on 64-bit platforms.
 endif()
 message("DEST_LIB_DIR is defined as $ENV{DEST_LIB_DIR}")
+
+if (NOT DEFINED ENV{DEST_ETC_DIR})
+    if ($ENV{GLOBUS_LOCATION} STREQUAL "/usr")
+        set(ENV{DEST_ETC_DIR} "/etc/grid-security")
+    else()
+        set(ENV{DEST_ETC_DIR} "$ENV{GLOBUS_LOCATION}/etc")
+    endif()
+endif()
+message("DEST_ETC_DIR is defined as $ENV{DEST_ETC_DIR}")
+
+if (NOT DEFINED ENV{DEST_BIN_DIR})
+    set(ENV{DEST_BIN_DIR} "$ENV{GLOBUS_LOCATION}/bin")
+endif()
+message("DEST_BIN_DIR is defined as $ENV{DEST_BIN_DIR}")
 #################################
 
 message("DSI library name will be: ${dsi_library_name}")
+message("Gridmap callout library name will be: ${gridmap_callout_library_name}")
 
 add_library(${dsi_library_name} SHARED globus_gridftp_server_iRODS.c)
+add_library(${gridmap_callout_library_name} SHARED gridmap_iRODS_callout.c libirodsmap.c)
 
-set_target_properties( ${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION} )
-target_link_libraries (${dsi_library_name} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+set_target_properties(${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION} )
+target_link_libraries(${dsi_library_name} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+
+set_target_properties(${gridmap_callout_library_name} PROPERTIES LINK_FLAGS ${gridmap_callout_library_LINK_FLAGS} VERSION ${GENERIC_LIB_VERSION} )
+target_link_libraries(${gridmap_callout_library_name} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+
+set(gridmap_callout_conf_name gridmap_iRODS_callout.conf)
+
+set(testirodsmap_exe "testirodsmap")
+set(testirodsmap_exe_LINK_FLAGS "-ldl -lglobus_gss_assist -lstdc++")
+add_executable(${testirodsmap_exe} testirodsmap.c libirodsmap.c)
+set_target_propertieS(${testirodsmap_exe} PROPERTIES LINK_FLAGS ${testirodsmap_exe_LINK_FLAGS})
+target_link_libraries(${testirodsmap_exe} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
 
 set(CMAKE_C_FLAGS "-g -O2 -Wall -lstdc++")
 
@@ -81,5 +113,8 @@ $ENV{GLOBUS_LOCATION}/lib/globus/include
 $ENV{GLOBUS_LOCATION}/lib64/globus/include)
 
 add_definitions(-DIRODS_MAPS_PATH=\"$ENV{RESOURCE_MAP_PATH}\")
-install(TARGETS ${dsi_library_name} DESTINATION $ENV{DEST_LIB_DIR})
+install(TARGETS ${dsi_library_name} ${gridmap_callout_library_name} DESTINATION $ENV{DEST_LIB_DIR})
+install(TARGETS ${testirodsmap_exe} DESTINATION $ENV{DEST_BIN_DIR})
+configure_file(${gridmap_callout_conf_name}.in ${gridmap_callout_conf_name})
+install(FILES ${gridmap_callout_conf_name} DESTINATION $ENV{DEST_ETC_DIR})
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
 * To activate the module, set the '$GSI_AUTH_CONF' environment variable in '/etc/gridftp.conf' to point to the configuration file - already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
 
-        $GSI_AUTH_CONF /etc/grid-security/gridmap_iRODS_callout.conf
+        $GSI_AUTHZ_CONF /etc/grid-security/gridmap_iRODS_callout.conf
 
 * Note that in order for this module to work, the server certificate DN must be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,27 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
        $homeDirPattern "/%s/home"
 
+2) Optionally, turn on the feature that would make the DSI module authenticate
+   as the rods admin user - but operate under the privileges of the target user.
+
+* Grant the GridFTP server access to the rods account:
+
+        $ iadmin aua rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
+        $ iadmin lua rods
+        rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
+
+* Make sure 'irodsUserName' is included in the '/path/to/.irodsEnv' file created above:
+
+        irodsUserName rods
+
+* Set the ````$irodsConnectAsAdmin````  environment variable in ````/etc/gridftp.conf```` to a non-empty value:
+
+        $irodsConnectAsAdmin "rods"
+
+  With all of this in place, it is no longer necessary to associate the DN of the server with each individual user - the server can now access user accounts through the rods account.
+
+  NOTE: this feature requires iRODS server at least 3.3 - GSI authentication with a proxy user breaks on iRODS 3.2 and earlier.
+
 
 Logrotate
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Prerequisite:
 - globus-gridftp-server-progs
 - libglobus-common-dev (.deb) or globus-common-devel (.rpm)
 - libglobus-gridftp-server-dev (.deb) or globus-gridftp-server-devel (.rpm)
+- libglobus-gridmap-callout-error-dev (.deb) or globus-gridmap-callout-error-devel (.rpm)
 (see http://www.ige-project.eu/downloads/software/releases/downloads)
 
 
@@ -49,6 +50,8 @@ server package without recompiling it.
    - IRODS_PATH --> path to the iRODS installation
    - FLAVOR --> (optional) flavors of the Globus packages which are already installed[a] 
    - DEST_LIB_DIR --> (optional) path to the folder in which the library will be copied
+   - DEST_BIN_DIR --> (optional) path to the folder in which binary executables (auxilliary tools) will be copied
+   - DEST_ETC_DIR --> (optional) path to the folder in which configuration files will be copied
    - RESOURCE_MAP_PATH --> (optional) path to the folder containing the 
      "irodsResourceMap.conf" file (see step 4 of section "Configure and run") 
 
@@ -204,6 +207,33 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
   NOTE: this feature requires iRODS server at least 3.3 - GSI authentication with a proxy user breaks on iRODS 3.2 and earlier.
 
+3) Optionally, use a Globus gridmap callout module to map subject DNs to iRODS
+   user names based on the existing mappings in iRODS (in r_user_auth table).
+   Configuring this feature eliminates the need for a local grid map file - all
+   user mappings can be done through the callout function.
+
+   The gridmap callout configuration file gets already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
+
+* To activate the module, set the '$GSI_AUTH_CONF' environment variable in '/etc/gridftp.conf' to point to the configuration file - already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
+
+        $GSI_AUTH_CONF /etc/grid-security/gridmap_iRODS_callout.conf
+
+* Note that in order for this module to work, the server certificate DN must be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
+
+* This module also supports invoking an iRODS server-side command with iexec in
+  case the DN does not have a mapping yet.  The command would receive the DN
+  being mapped as a single argument and may for example add a mapping to an
+  existing account, or create a new account.
+
+  To enable this feature, set the '$irodsDnCommand' environment variable in '/etc/gridftp.conf' to the name of the command to execute.  On the iRODS server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.  For example, to invoke a script called 'createUser', add:
+
+        $irodsDnCommand "createUser"
+
+* There is also a command line utility to test the mapping lookups (and script execution) that would otherwise be done by the gridmap module.  This utility command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be invoked with the DN as a single argument.  The command would need to see the same environment variables as the gridmap module loaded into the GridFTP server - specifically, '$irodsEnvFile' pointing to the iRODS  environment and '$irodsDnCommand' setting the command to invoke if no mapping is found.  The 'testirodsmap' command also needs to have access to the server host certificate - and find it either through the default mechanisms used by Globus GSI or by explicitly setting the 'X509_USER_CERT' and 'X509_USER_KEY' environment variables.  (The easiest way is to run the command in the same environment as the Globus GridFTP server, i.e., under the root account).  For example, invoke the command with:
+
+        export irodsDnCommand=createUser 
+        export irodsEnvFile=/path/to/.irodsEnv
+        $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 
 Logrotate
 --------------------------------
@@ -237,4 +267,8 @@ Licence
  Author: Roberto Mucci - SCAI - CINECA
  Email:  hpc-service@cineca.it
 
+ Globus gridmap iRODS callout to map subject DNs to iRODS accounts.
+ 
+ Author: Vladimir Mencl, University of Canterbury
+ Email:  vladimir.mencl@canterbury.ac.nz
 

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -655,12 +655,15 @@ globus_l_gfs_iRODS_destroy(
 {
     globus_l_gfs_iRODS_handle_t *       iRODS_handle;
 
-    iRODS_handle = (globus_l_gfs_iRODS_handle_t *) user_arg;
-    globus_mutex_destroy(&iRODS_handle->mutex);
-    globus_fifo_destroy(&iRODS_handle->rh_q);
-    iRODS_disconnect(iRODS_handle->conn);
+    if (user_arg != NULL) {
 
-    globus_free(iRODS_handle);
+		iRODS_handle = (globus_l_gfs_iRODS_handle_t *) user_arg;
+		globus_mutex_destroy(&iRODS_handle->mutex);
+		globus_fifo_destroy(&iRODS_handle->rh_q);
+		iRODS_disconnect(iRODS_handle->conn);
+
+		globus_free(iRODS_handle);
+    };
 }
 
 /*************************************************************************

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -46,6 +46,9 @@
 /* name of environment variable to check for the homeDirPattern */
 #define HOMEDIR_PATTERN "homeDirPattern"
 
+/* if present, connect as the admin account stored in rodsEnv and not as the user */
+#define IRODS_CONNECT_AS_ADMIN "irodsConnectAsAdmin"
+
 static int                              iRODS_l_dev_wrapper = 10;
 struct iRODS_Resource
 {
@@ -614,8 +617,13 @@ globus_l_gfs_iRODS_start(
     }
     free(username_to_parse);
 
-    globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: calling rcConnect(%s,%i,%s,%s)\n", iRODS_handle->hostname, iRODS_handle->port, iRODS_handle->user, iRODS_handle->zone);
-    iRODS_handle->conn = rcConnect(iRODS_handle->hostname, iRODS_handle->port, iRODS_handle->user, iRODS_handle->zone, 0, &errMsg);
+    if (getenv(IRODS_CONNECT_AS_ADMIN)!=NULL) {
+        globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: calling _rcConnect(%s,%i,%s,%s, %s, %s)\n", iRODS_handle->hostname, iRODS_handle->port, myRodsEnv.rodsUserName, myRodsEnv.rodsZone, iRODS_handle->user, iRODS_handle->zone);
+        iRODS_handle->conn = _rcConnect(iRODS_handle->hostname, iRODS_handle->port, myRodsEnv.rodsUserName, myRodsEnv.rodsZone, iRODS_handle->user, iRODS_handle->zone, &errMsg, 0, 0);
+    } else {
+        globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: calling rcConnect(%s,%i,%s,%s)\n", iRODS_handle->hostname, iRODS_handle->port, iRODS_handle->user, iRODS_handle->zone);
+        iRODS_handle->conn = rcConnect(iRODS_handle->hostname, iRODS_handle->port, iRODS_handle->user, iRODS_handle->zone, 0, &errMsg);
+    }
     if (iRODS_handle->conn == NULL) {
         tmp_str = globus_common_create_string("rcConnect failed::\n  '%s'. Host: '%s', Port: '%i', UserName '%s', Zone '%s'\n",errMsg.msg, iRODS_handle->hostname,
         iRODS_handle->port, iRODS_handle->user, iRODS_handle->zone);

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -634,7 +634,7 @@ globus_l_gfs_iRODS_start(
 
     homeDirPattern = getenv(HOMEDIR_PATTERN);
     if (homeDirPattern == NULL) { homeDirPattern = DEFAULT_HOMEDIR_PATTERN; }
-    finished_info.info.session.home_dir = globus_common_create_string(homeDirPattern, iRODS_handle->zone, user_name);
+    finished_info.info.session.home_dir = globus_common_create_string(homeDirPattern, iRODS_handle->zone, iRODS_handle->user);
     free(user_name);
 
     globus_gridftp_server_operation_finished(op, GLOBUS_SUCCESS, &finished_info);

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -266,7 +266,6 @@ iRODS_l_stat1(
     }
     else
     {
-        char sizeStr[NAME_LEN];
         dataObjInp_t dataObjInp; 
         rodsObjStat_t *rodsObjStatOut = NULL; 
         bzero (&dataObjInp, sizeof (dataObjInp)); 

--- a/gridmap_iRODS_callout.c
+++ b/gridmap_iRODS_callout.c
@@ -1,0 +1,299 @@
+/*
+ * Contributed to the EUDAT DSI interface project by
+ * Vladimir Mencl <vladimir.mencl@canterbury.ac.nz> (University of Canterbury, New Zealand)
+ *
+ * This module file implements the required interface of a gridmap callout function.
+ * The code in this module heavily borrows from the
+ * gridmap_verify_myproxy_callout, Globus Toolkit 6.0,
+ * Copyright 1999-2006 University of Chicago
+ *
+ * As such, this code is distributed under the Apache License 2.0, as used by
+ * the Globus Toolkit project.
+ *
+ */
+
+#include "globus_common.h"
+#include "gssapi.h"
+#include "globus_gss_assist.h"
+#include "globus_gsi_credential.h"
+#include "globus_gridmap_callout_error.h"
+
+#include "globus_gridftp_server.h"
+
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+
+#include <stdlib.h>
+#include <openssl/ssl.h>
+
+#include "libirodsmap.h"
+
+/* Get the subject from the globus context */
+globus_result_t
+gridmap_iRODS_callout_get_subject(
+    gss_ctx_id_t                        context,
+    char **                             subject)
+{
+    gss_name_t                          peer;
+    gss_buffer_desc                     peer_name_buffer;
+    OM_uint32                           major_status;
+    OM_uint32                           minor_status;
+    int                                 initiator;
+    globus_result_t                     result = GLOBUS_SUCCESS;
+
+    major_status = gss_inquire_context(&minor_status,
+                                       context,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       &initiator,
+                                       GLOBUS_NULL);
+
+    if(GSS_ERROR(major_status))
+    {
+        GLOBUS_GRIDMAP_CALLOUT_GSS_ERROR(result, major_status, minor_status);
+        goto error;
+    }
+
+    major_status = gss_inquire_context(&minor_status,
+                                       context,
+                                       initiator ? GLOBUS_NULL : &peer,
+                                       initiator ? &peer : GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL,
+                                       GLOBUS_NULL);
+
+    if(GSS_ERROR(major_status))
+    {
+        GLOBUS_GRIDMAP_CALLOUT_GSS_ERROR(result, major_status, minor_status);
+        goto error;
+    }
+
+    major_status = gss_display_name(&minor_status,
+                                    peer,
+                                    &peer_name_buffer,
+                                    GLOBUS_NULL);
+
+    if(GSS_ERROR(major_status))
+    {
+        GLOBUS_GRIDMAP_CALLOUT_GSS_ERROR(result, major_status, minor_status);
+        gss_release_name(&minor_status, &peer);
+        goto error;
+    }
+
+
+    *subject = globus_libc_strdup(peer_name_buffer.value);
+    gss_release_buffer(&minor_status, &peer_name_buffer);
+    gss_release_name(&minor_status, &peer);
+
+    return GLOBUS_SUCCESS;
+
+error:
+    return result;
+}
+
+globus_result_t
+gridmap_iRODS_mapuser(char * subject, char ** found_identity, char * desired_identity) {
+  char * user = NULL;
+  char * zone = NULL;
+  char * desired_user = NULL;
+  char * desired_zone = NULL;
+  char * identity = NULL;
+  int result = GLOBUS_SUCCESS;
+
+  if (desired_identity != NULL) {
+
+      // split the desired_identity into user#zone
+      // if the '#' separator is present
+      char * separator_ptr;
+      if ( (separator_ptr = strchr(desired_identity,'#')) != NULL ) {
+    	  // NOTE: these strdup calls are not checked
+          desired_user = strndup(desired_identity, separator_ptr - desired_identity);
+          desired_zone = strdup(separator_ptr + 1);
+      } else {
+          desired_user = strdup(desired_identity);
+          desired_zone = NULL;
+      };
+  };
+
+  if ( get_irods_mapping(subject, &user, &zone, desired_user, desired_zone ) == 0) {
+    identity=calloc(1, strlen(user)+1+strlen(zone)+1);
+    if (identity != NULL) {
+        strcpy(identity,user);
+        strcat(identity,"#");
+        strcat(identity,zone);
+        *found_identity=identity;
+        result = GLOBUS_SUCCESS;
+    } else {
+    	result = ENAMETOOLONG;
+    }
+    free(user);
+    free(zone);
+  } else {
+    result = GLOBUS_FAILURE;
+  };
+
+  // cleanup - in case we created these
+  if (desired_user != NULL) free(desired_user);
+  if (desired_zone != NULL) free(desired_zone);
+  return result;
+}
+
+globus_result_t
+gridmap_iRODS_callout(
+    va_list                             ap)
+{
+    gss_ctx_id_t                        context;
+    char *                              service;
+    char *                              desired_identity;
+    char *                              identity_buffer;
+    char *                              found_identity = NULL;
+    char *                              subject = NULL;
+    unsigned int                        buffer_length;
+    globus_result_t                     result = GLOBUS_SUCCESS;
+    char *                              shared_user_cert = NULL;
+    int                                 rc;
+
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout starting\n");
+
+    rc = globus_module_activate(GLOBUS_GSI_GSS_ASSIST_MODULE);
+    rc = globus_module_activate(GLOBUS_GSI_GSSAPI_MODULE);
+    rc = globus_module_activate(GLOBUS_GRIDMAP_CALLOUT_ERROR_MODULE);
+
+    context = va_arg(ap, gss_ctx_id_t);
+    service = va_arg(ap, char *);
+    desired_identity = va_arg(ap, char *);
+    identity_buffer = va_arg(ap, char *);
+    buffer_length = va_arg(ap, unsigned int);
+
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: context = %p\n", context);
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: service = %s\n", service);
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: desired_identity = %s\n", desired_identity);
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: identity_buffer = %s\n", identity_buffer);
+    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: buffer_length = %d\n", buffer_length);
+
+    if(strcmp(service, "sharing") == 0)
+    {
+        shared_user_cert = va_arg(ap, char *);
+
+        result = globus_gsi_cred_read_cert_buffer(
+            shared_user_cert, NULL, NULL, NULL, &subject);
+        if(result != GLOBUS_SUCCESS)
+        {
+            GLOBUS_GRIDMAP_CALLOUT_ERROR(
+                result,
+                GLOBUS_GRIDMAP_CALLOUT_GSSAPI_ERROR,
+                ("Could not extract shared user identity."));
+            goto error;
+        }
+	globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: sharing: subject = %s\n", subject);
+    }
+    else
+    {
+        // Extract user identity
+        // Reuse code from gridmap_callout_verify_myproxy
+        result = gridmap_iRODS_callout_get_subject(context, &subject);
+        if (result == GLOBUS_SUCCESS)
+	    globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: context: subject = %s\n", subject);
+
+    }
+
+    if(result != GLOBUS_SUCCESS || subject == NULL)
+    {
+        GLOBUS_GRIDMAP_CALLOUT_ERROR(
+            result,
+            GLOBUS_GRIDMAP_CALLOUT_GSSAPI_ERROR,
+            ("Could not extract user identity."));
+        goto error;
+    }
+
+    // Perform the mapping now - set found_identity
+    result = gridmap_iRODS_mapuser(subject, &found_identity, desired_identity);
+    if(result == GLOBUS_SUCCESS)
+    {
+	globus_gfs_log_message(GLOBUS_GFS_LOG_DUMP, "gridmap_iRODS_callout: identity: %s\n", found_identity);
+        if(desired_identity && strcmp(found_identity, desired_identity) != 0)
+        {
+            GLOBUS_GRIDMAP_CALLOUT_ERROR(
+                result,
+                GLOBUS_GRIDMAP_CALLOUT_LOOKUP_FAILED,
+                ("Credentials specify id of %s, can not allow id of %s.\n",
+                 found_identity, desired_identity));
+            globus_free(found_identity);
+            goto error;
+        }
+    }
+    else
+    {
+        result = GLOBUS_SUCCESS;
+        /* proceed with gridmap lookup */
+        if(desired_identity == NULL)
+        {
+            rc = globus_gss_assist_gridmap(subject, &found_identity);
+            if(rc != 0)
+            {
+                GLOBUS_GRIDMAP_CALLOUT_ERROR(
+                    result,
+                    GLOBUS_GRIDMAP_CALLOUT_LOOKUP_FAILED,
+                    ("Could not map %s\n", subject));
+                goto error;
+            }
+        }
+        else
+        {
+            rc = globus_gss_assist_userok(subject, desired_identity);
+            if(rc != 0)
+            {
+                GLOBUS_GRIDMAP_CALLOUT_ERROR(
+                    result,
+                    GLOBUS_GRIDMAP_CALLOUT_LOOKUP_FAILED,
+                    ("Could not map %s to %s\n",
+                     subject, desired_identity));
+                goto error;
+            }
+            found_identity = globus_libc_strdup(desired_identity);
+        }
+    }
+
+    if(found_identity)
+    {
+        if(strlen(found_identity) + 1 > buffer_length)
+        {
+            GLOBUS_GRIDMAP_CALLOUT_ERROR(
+                result,
+                GLOBUS_GRIDMAP_CALLOUT_BUFFER_TOO_SMALL,
+                ("Local identity length: %d Buffer length: %d\n",
+                 strlen(found_identity), buffer_length));
+        }
+        else
+        {
+            strcpy(identity_buffer, found_identity);
+        }
+        globus_free(found_identity);
+    }
+
+
+error:
+
+    if(subject)
+    {
+        globus_free(subject);
+    }
+
+    globus_module_deactivate(GLOBUS_GRIDMAP_CALLOUT_ERROR_MODULE);
+    globus_module_deactivate(GLOBUS_GSI_GSSAPI_MODULE);
+    globus_module_deactivate(GLOBUS_GSI_GSS_ASSIST_MODULE);
+
+    return result;
+}
+
+void libirodsmap_log(int level, const char * message, const char * param, int status) {
+    globus_gfs_log_message(level, message, param, status);
+}
+

--- a/gridmap_iRODS_callout.conf.in
+++ b/gridmap_iRODS_callout.conf.in
@@ -1,0 +1,1 @@
+globus_mapping lib${gridmap_callout_library_name} gridmap_iRODS_callout

--- a/libirodsmap.c
+++ b/libirodsmap.c
@@ -1,0 +1,293 @@
+/*
+ * Contributed to the EUDAT DSI interface project by
+ * Vladimir Mencl <vladimir.mencl@canterbury.ac.nz> (University of Canterbury, New Zealand)
+ *
+ * Existing project licenses apply.
+ *
+ * This module file has the core logic of talking to the iRODS API.
+ *
+ */
+
+#include "rodsClient.h"
+//#include "rodsGenQueryNames.h"
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "libirodsmap.h"
+
+/** Open an iRODS connection */
+int libirodsmap_connect(rcComm_t ** rcComm_out) {
+    rodsEnv myRodsEnv;
+    rErrMsg_t errMsg;
+    int rc = 0;
+    rcComm_t * rcComm = NULL;
+
+    rc = getRodsEnv(&myRodsEnv);
+    if (rc != 0) {
+        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_connect: getRodsEnv failed: %s%d\n", "", rc);
+        goto connect_error;
+    };
+
+    rcComm = rcConnect(myRodsEnv.rodsHost, myRodsEnv.rodsPort, myRodsEnv.rodsUserName, myRodsEnv.rodsZone, 0, &errMsg);
+    if (rcComm == NULL) {
+        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_connect: rcConnect failed ignore %s\n", errMsg.msg, 0);
+        goto connect_error;
+    };
+    libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_connect: connected to iRODS server (%s:%d)\n", myRodsEnv.rodsHost, myRodsEnv.rodsPort);
+
+    rc = clientLogin(rcComm);
+    if (rc != 0) {
+        libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_connect: clientLogin failed: %s%d\n", "", rc);
+        goto connect_error;
+    };
+
+
+connect_error:
+    if (rc != 0) {
+       // cleanup
+       if (rcComm != NULL) {
+           rcDisconnect(rcComm);
+           rcComm = NULL;
+       };
+
+    } else {
+       *rcComm_out = rcComm;
+    }
+    return rc;
+}
+
+/** Add to inxValPair a SQL condition for equality on column inx to value value_to_check */
+int libirodsmap_add_sqlcond(inxValPair_t *inxValPair, int inx, const char *value_to_check) {
+	char * condStr;
+
+	// NOTE: no need to check for special characters ("'") - even with
+	// plain substitution, rcGenQuery interprets only the leading and
+	// trailing "'" as special and correctly handles queries with DNs
+	// containing "'" (e.g., CN=John O'Brien)
+	int extra_chars = 3; // we use "='%s'"
+	condStr = malloc(strlen(value_to_check)+extra_chars+1);
+	if (condStr == NULL) return ENAMETOOLONG;
+
+	sprintf(condStr,"='%s'",value_to_check);
+	//libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_query_dn: DEBUG: adding condition %s (column %d)\n", condStr, inx);
+
+    // Useful helper method:
+    // int addInxVal (inxValPair_t *inxValPair, int inx, char *value);
+    // NOTE: string passed to this method gets copied with strdup -
+    // and we are still responsible for the pointer we pass
+
+    addInxVal(inxValPair, inx, condStr);
+    free(condStr);
+    return 0;
+}
+
+/** Query the iCAT for the username+zone associated with a DN (optionally providing a desired username+zone)
+ *
+ * The SQL equivalent of the query is:
+ *
+ * select user_name, user_zone from r_user_main, r_user_auth where r_user_main.user_id = r_user_auth.user_id and user_auth_name = '/C=XX/O=YYY/CN=Example User';
+ *
+ * and iquest is:
+ *
+ * iquest "select USER_NAME, USER_ZONE where USER_DN = '/C=XX/O=YYY/CN=Example User'"
+ *
+ * Optionally (if desired_username+zone is specified) extended to:
+ *
+ * iquest "select USER_NAME, USER_ZONE where USER_DN = '/C=XX/O=YYY/CN=Example User' AND USER_NAME = 'example.user' AND USER_ZONE = 'ExampleZone'"
+ *
+ */
+int libirodsmap_query_dn(rcComm_t * rcComm, const char * dn, char ** user, char ** zone, const char * desired_user, const char * desired_zone) {
+    int rc = 0;
+
+    genQueryInp_t *qi = NULL;
+    genQueryOut_t *qo = NULL;
+
+    // prepare query input in qi
+    qi = calloc(1, sizeof(genQueryInp_t));
+    if (qi == NULL) {
+    	rc = ENAMETOOLONG;
+    	goto query_error;
+    }
+
+    qi->maxRows = 10; // must specify non-zero - but really only want one result
+
+    // Prepare qi->selectInp - output field selection
+    // now I need to request USER_NAME in selectInp (COL_USER_NAME, COL_USER_ZONE) - with option 0 (no ORDER BY flags)
+    // Useful helper method:
+    // int addInxIval (inxIvalPair_t *inxIvalPair, int inx, int value);
+    addInxIval(&qi->selectInp, COL_USER_NAME, 0);
+    addInxIval(&qi->selectInp, COL_USER_ZONE, 0);
+
+    // Specify condition with DN in sqlCondInp (COL_USER_DN)
+    if ( (rc = libirodsmap_add_sqlcond(&qi->sqlCondInp, COL_USER_DN, dn)) != 0) goto query_error;
+
+    // Optionally, if desired_user/zone have been set, add these as conditions too.
+    if (desired_user != NULL)
+    	if ( (rc = libirodsmap_add_sqlcond(&qi->sqlCondInp, COL_USER_NAME, desired_user)) != 0) goto query_error;
+    if (desired_zone != NULL)
+    	if ( (rc = libirodsmap_add_sqlcond(&qi->sqlCondInp, COL_USER_ZONE, desired_zone)) != 0) goto query_error;
+
+    // invoke: int rcGenQuery (rcComm_t *conn, genQueryInp_t *genQueryInp, genQueryOut_t **genQueryOut)
+    rc = rcGenQuery(rcComm, qi, &qo);
+
+    // check genquery result
+    if (rc != 0) {
+    	// if the error is not CAT_NO_ROWS_FOUND, log it
+        if (rc != CAT_NO_ROWS_FOUND)
+            libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_query_dn: rcGenQuery failed: %s%d\n", "", rc);
+        else
+        	libirodsmap_log(IRODSMAP_LOG_INFO,"libirodsmap_query_dn: DN was not found: %s (rc %d)\n", dn, rc);
+
+        goto query_error;
+    };
+
+    // rcGenQuery has succeeded.
+	// We should see qo->rowCnt=1, qo->attriCnt=2
+	if (qo->rowCnt==1 && qo->attriCnt==2) {
+	    // qo->sqlResult is array sqlResult[attriCnt] where .value has values for
+	    // all rows (seek in the string with row number - but we don't have to with just one row)
+	    int attrIdx;
+	    *user=NULL;
+	    *zone=NULL;
+	    for (attrIdx=0; attrIdx < qo->attriCnt; attrIdx++) {
+			if (qo->sqlResult[attrIdx].attriInx==COL_USER_NAME) {
+				*user=strdup(qo->sqlResult[attrIdx].value);
+			    libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_query_dn: rcGenQuery returned user %s (rc=%d)\n", *user, rc);
+			};
+			if (qo->sqlResult[attrIdx].attriInx==COL_USER_ZONE) {
+				*zone=strdup(qo->sqlResult[attrIdx].value);
+			    libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_query_dn: rcGenQuery returned zone %s (rc=%d)\n", *zone, rc);
+			};
+	    };
+	    // last check: if both user and zone are set.
+	    // If not, either something went wrong with the query, or stdup failed
+	    if (*user == NULL || *zone == NULL) {
+	    	rc = ENAMETOOLONG;
+	    	//free what has been allocated
+	    	if (*user != NULL) { free(*user); *user=NULL; };
+	    	if (*zone != NULL) { free(*zone); *zone=NULL; };
+	    }
+	    // in this case, rc == 0
+	} else {
+		// if we did not get exactly one row with two attributes, we mark it as a failure
+		rc = CAT_NO_ROWS_FOUND;
+		libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_query_dn: rcGenQuery returned %s%d rows\n", "", qo->rowCnt);
+		libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_query_dn: rcGenQuery returned %s%d attributes\n", "", qo->attriCnt);
+	}
+	// only if rcGenQuery was successful we free genQuery_out
+	// And we use freeGenQueryOut which dives into the data structures
+	// (and also sets the pointer to NULL - that's why it's passed by reference)
+	freeGenQueryOut(&qo);
+
+ query_error:
+	/* free input structure
+	 * use these methods to release the allocations made by addInxIval/addInxVal
+	 * int clearInxIval (inxIvalPair_t *inxIvalPair);
+	 * int clearInxVal (inxValPair_t *inxValPair);
+	 */
+    if (qi != NULL) {
+		clearInxIval(&qi->selectInp);
+		clearInxVal(&qi->sqlCondInp);
+		free(qi);
+    }
+
+
+    return rc;
+}
+
+
+int libirodsmap_exec_command(rcComm_t * rcComm, const char * dnCommand, const char * dn)
+{
+    execCmd_t *execCmd = NULL;
+    execCmdOut_t *execCmdOut = NULL;
+    int rc = 0;
+
+    execCmd = calloc(1, sizeof(execCmd_t));
+    if (execCmd == NULL) {
+    	rc = ENAMETOOLONG;
+    	goto exec_command_error;
+    }
+
+    if ( (strlen(dnCommand)+1) <= sizeof(execCmd->cmd) )
+        strcpy(execCmd->cmd,dnCommand);
+    else {
+    	rc = ENAMETOOLONG;
+        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_exec_command: " IRODS_DN_COMMAND " too long: %s\n", dnCommand, 0);
+    	goto exec_command_error;
+    }
+    if ( (strlen(dn)+1) <= sizeof(execCmd->cmdArgv) )
+        strcpy(execCmd->cmdArgv,dn);
+    else {
+    	rc = ENAMETOOLONG;
+        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_exec_command: DN too long: %s\n", dn, 0);
+    	goto exec_command_error;
+    }
+
+    // Invoke: int rcExecCmd (rcComm_t *conn, execCmd_t *execCmdInp, execCmdOut_t **execCmdOut)
+    libirodsmap_log(IRODSMAP_LOG_INFO,"libirodsmap_exec_command: invoking rsExecCmd with command %s\n", dnCommand, 0);
+    libirodsmap_log(IRODSMAP_LOG_INFO,"libirodsmap_exec_command: invoking rsExecCmd with DN %s\n", dn, 0);
+    rc = rcExecCmd (rcComm, execCmd, &execCmdOut);
+    if (rc != 0)
+    	libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_exec_command: rsExecCmd returned %s%d\n", "", rc);
+
+exec_command_error:
+    // cleanup
+	if (execCmd != NULL) { free(execCmd); execCmd = NULL; };
+	if (execCmdOut != NULL) { free(execCmdOut); ; execCmdOut = NULL; };
+
+	return rc;
+}
+
+
+
+/** Get the iRODS account name based on a DN.
+ *
+ * This is a high-level routine that connects as rods and tries looking the name up based on the DN.
+ *
+ * If successful, the routine allocates the user and zone strings, which are then the callers responsibility to free.
+ *
+ * Params:
+ *     dn - the DN to map
+ *     user, zone: upon success, return a pointer to the mapped user and zone here.
+ *                 The caller is responsible for freeing the pointers.
+ *     desired_user, desired zone: if the user has a preferred mapping, search if this username already exists.
+ *
+ * Returns: 0 if the mapping was successfully obtained.  In this case, user and zone would be set.
+ *          non-zero otherwise (including when a mapping did not exist.  The value would be CAT_NO_ROWS_FOUND in thic case)
+ */
+
+int get_irods_mapping(const char * dn, char ** user, char ** zone, const char * desired_user, const char * desired_zone)
+{
+    rcComm_t *rcComm = NULL;
+    int rc = 0;
+
+    if ( (rc=libirodsmap_connect(&rcComm)) != 0 ) goto irods_mapping_error;
+
+    rc = libirodsmap_query_dn(rcComm, dn, user, zone, desired_user, desired_zone);
+    if ( rc !=0 && rc != CAT_NO_ROWS_FOUND) goto irods_mapping_error;
+
+    // If the user was not found and if configured to run a script, invoke the command now and try querying again
+    if ( rc == CAT_NO_ROWS_FOUND ) {
+    	char * dnCommand = getenv(IRODS_DN_COMMAND);
+    	if (dnCommand != NULL) {
+    	    if ( (rc=libirodsmap_exec_command(rcComm, dnCommand, dn)) != 0 ) goto irods_mapping_error;
+    	    // try one more time the query - if the command changed something and the DN has a mapping now
+    	    rc = libirodsmap_query_dn(rcComm, dn, user, zone, desired_user, desired_zone);
+    	    if ( rc !=0 && rc != CAT_NO_ROWS_FOUND) goto irods_mapping_error;
+    	}
+    }
+    // now, all attempts are completed (and none of them ran into an error)
+    // rc is either 0 (user+zone found) or CAT_NO_ROWS_FOUND
+    // nothing to do: user+zone have already been set
+    // so just return rc
+
+irods_mapping_error:
+	// cleanup
+	if (rcComm != NULL) {
+		// disconnect
+		rcDisconnect(rcComm);
+		rcComm = NULL;
+	}
+    return rc;
+}

--- a/libirodsmap.h
+++ b/libirodsmap.h
@@ -1,0 +1,54 @@
+/*
+ * Contributed to the EUDAT DSI interface project by
+ * Vladimir Mencl <vladimir.mencl@canterbury.ac.nz> (University of Canterbury, New Zealand)
+ *
+ * Existing project licenses apply.
+ *
+ * This module file has the core logic of talking to the iRODS API.
+ *
+ */
+
+
+#ifndef LIB_IRODS_MAP
+#define LIB_IRODS_MAP 1
+
+// Configuration parameters
+
+// Name of environment variable holding the name of an iRODS
+// server-side command to invoke when a DN match is not found
+#define IRODS_DN_COMMAND "irodsDnCommand"
+
+
+/** Get the iRODS account name based on a DN.
+ *
+ * This is a high-level routine that connects as rods and tries looking the name up based on the DN.
+ *
+ * If successful, the routine allocates the user and zone strings, which are then the callers responsibility to free.
+ *
+ * Params:
+ *     dn - the DN to map
+ *     user, zone: upon success, return a pointer to the mapped user and zone here.
+ *                 The caller is responsible for freeing the pointers.
+ *     desired_user, desired zone: if the user has a preferred mapping, search if this username already exists.
+ *
+ * Returns: 0 if the mapping was successfully obtained.  In this case, user and zone would be set.
+ *          non-zero otherwise (including when a mapping did not exist.  The value would be CAT_NO_ROWS_FOUND in thic case)
+ */
+
+int get_irods_mapping(const char * dn, char ** user, char ** zone, const char * desired_user, const char * desired_zone);
+
+/** Logging function that can translate to globus loggign or stderr
+ * For simplicity, a single fucntion taking a string and an int parameter.
+ * String is passed first (and can be empty if not needed).
+ * Integer can be omitted from the formatting message.
+ */
+
+void libirodsmap_log(int level, const char * message, const char * param, int status);
+
+/* Log levels for logging - based on Globus values in globus_gridftp_server.h */
+#define IRODSMAP_LOG_ERR    1
+#define IRODSMAP_LOG_WARN   2
+#define IRODSMAP_LOG_INFO   8
+#define IRODSMAP_LOG_DEBUG 16 // GLOBUS_GFS_LOG_DUMP
+
+#endif

--- a/setup.sh.template
+++ b/setup.sh.template
@@ -11,5 +11,11 @@ export IRODS_PATH=""          #path to the iRODS installation
 export DEST_LIB_DIR=""        #(optional) path to the folder in which the library will be copied
                               #such as ${GLOBUS_LOCATION}/lib64
 
+export DEST_BIN_DIR=""        #(optional) path to the folder in which binary executables (auxilliary tools) will be copied
+                              #such as ${GLOBUS_LOCATION}/lib64
+
+export DEST_ETC_DIR=""        #(optional) path to the folder in which configuration files will be copied
+                              #such as ${GLOBUS_LOCATION}/lib64
+
 export RESOURCE_MAP_PATH=""   #(optional) path to the folder containing the 
                               #"irodsResourceMap.conf" file (see step 4 of section "Configure and run") 

--- a/testirodsmap.c
+++ b/testirodsmap.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <unistd.h>
+
+#include "libirodsmap.h"
+
+int main(int argc, char **argv)
+{
+    char * user = NULL;
+    char * zone = NULL;
+    int rc = 0;
+    if (argc>=2) {
+        if ( (rc = get_irods_mapping(argv[1],&user,&zone, NULL, NULL)) == 0)
+            fprintf(stdout, "Mapping for %s is %s#%s\n", argv[1], user, zone);
+        else
+	        fprintf(stderr, "Mapping for %s failed (%d)\n", argv[1], rc);
+        return rc;
+    } else {
+        fprintf(stderr,"Usage: %s <DN>\n", argv[0]);
+        return -2;
+    };
+}
+
+void libirodsmap_log(int level, const char * message, const char * param, int status) {
+    fprintf(stderr,"Level(%d) ", level);
+    fprintf(stderr, message, param, status);
+}
+


### PR DESCRIPTION
Hi Roberto,

This is the feature I discussed in #5.

I have it working on my test server, with reasonable test cases tried out.

As discussed, the feature is not activated by default, and the deployer would have to add an extra line to /etc/gridftp.conf to start loading the gridmap_iRODS_callout module.

I have also added another feature (also discussed in #5) to the DSI module directly, changing how the iRODS connection is made - if an environment variable called "$irodsConnectAsAdmin" is set, the code would switch to a different form of the rcConnect call, passing rods as proxyUser and the actual user name as clientUser.  If the variable is not set, the original form of rcConnect is used.

I have also made a few fixes to the DSI module:
*  Check for NULL in globus_l_gfs_iRODS_destroy (the module was segfaulting when GridFTP server called the destroy method without having created a connection first)
*  Use strdup to make copies of strings on the stack
*  homeDir: use parsed username without zone (after the mapping module started returning full usernames including zone, the homeDir was being set to "wrong" directory "/<zone>/home/<user>#<zone>/".  Use the parsed username without zone instead.

Note that in the gridmap callout code, I've reused the stub from globus_gridmap_verify_myproxy_callout  - but as it comes from the same source as the DSI module skeleton, I would not see it as a licensing issue.

Please let me know if the pull request is looking all right to you.

Cheers,
Vlad




