### PR TITLE
iRODS 4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,28 @@ endif()
 
 if (DEFINED ENV{IRODS_PATH})
     message("IRODS_PATH is defined as $ENV{IRODS_PATH}")
+    if ($ENV{IRODS_PATH} STREQUAL "/usr")
+        add_definitions(-DIRODS_HEADER_HPP)
+        set(irods_include_path_list "$ENV{IRODS_PATH}/include/irods")
+        set(irods_link_obj_path "$ENV{IRODS_PATH}/lib/libRodsAPIs.a"
+                "-lrt"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libjansson.a"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_chrono.a"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_filesystem.a"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_regex.a"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_system.a"
+                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_thread.a")
+    else()
+        set(irods_include_path_list "$ENV{IRODS_PATH}/lib/api/include"
+                "$ENV{IRODS_PATH}/lib/core/include"
+                "$ENV{IRODS_PATH}/server/icat/include"
+                "$ENV{IRODS_PATH}/lib/md5/include/"
+                "$ENV{IRODS_PATH}/lib/sha1/include/"
+                "$ENV{IRODS_PATH}/server/core/include/"
+                "$ENV{IRODS_PATH}/server/drivers/include/"
+                "$ENV{IRODS_PATH}/server/re/include/")
+        set(irods_link_obj_path "$ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a")
+    endif()
 else()
     message( FATAL_ERROR "IRODS_PATH is NOT defined, CMake will exit." )
 endif()
@@ -84,10 +106,10 @@ add_library(${dsi_library_name} SHARED globus_gridftp_server_iRODS.c)
 add_library(${gridmap_callout_library_name} SHARED gridmap_iRODS_callout.c libirodsmap.c)
 
 set_target_properties(${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION} )
-target_link_libraries(${dsi_library_name} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+target_link_libraries(${dsi_library_name} ${irods_link_obj_path})
 
 set_target_properties(${gridmap_callout_library_name} PROPERTIES LINK_FLAGS ${gridmap_callout_library_LINK_FLAGS} VERSION ${GENERIC_LIB_VERSION} )
-target_link_libraries(${gridmap_callout_library_name} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+target_link_libraries(${gridmap_callout_library_name} ${irods_link_obj_path})
 
 set(gridmap_callout_conf_name gridmap_iRODS_callout.conf)
 
@@ -95,22 +117,17 @@ set(testirodsmap_exe "testirodsmap")
 set(testirodsmap_exe_LINK_FLAGS "-ldl -lglobus_gss_assist -lstdc++")
 add_executable(${testirodsmap_exe} testirodsmap.c libirodsmap.c)
 set_target_propertieS(${testirodsmap_exe} PROPERTIES LINK_FLAGS ${testirodsmap_exe_LINK_FLAGS})
-target_link_libraries(${testirodsmap_exe} $ENV{IRODS_PATH}/lib/core/obj/libRodsAPIs.a)
+target_link_libraries(${testirodsmap_exe} ${irods_link_obj_path})
 
 set(CMAKE_C_FLAGS "-g -O2 -Wall -lstdc++")
 
-include_directories($ENV{IRODS_PATH}/lib/api/include  
-$ENV{IRODS_PATH}/lib/core/include
-$ENV{IRODS_PATH}/server/icat/include 
-$ENV{IRODS_PATH}/lib/md5/include/ 
-$ENV{IRODS_PATH}/lib/sha1/include/
-$ENV{IRODS_PATH}/server/core/include/ 
-$ENV{IRODS_PATH}/server/drivers/include/ 
-$ENV{IRODS_PATH}/server/re/include/ 
-$ENV{GLOBUS_LOCATION}/include/globus 
-$ENV{GLOBUS_LOCATION}/include/gcc64pthr
-$ENV{GLOBUS_LOCATION}/lib/globus/include
-$ENV{GLOBUS_LOCATION}/lib64/globus/include)
+include_directories(${irods_include_path_list})
+include_directories($ENV{GLOBUS_LOCATION}/include/globus
+        $ENV{GLOBUS_LOCATION}/lib/globus/include
+        $ENV{GLOBUS_LOCATION}/lib64/globus/include)
+if (DEFINED ENV{FLAVOR})
+    include_directories($ENV{GLOBUS_LOCATION}/include/ENV{FLAVOR})
+endif()
 
 add_definitions(-DIRODS_MAPS_PATH=\"$ENV{RESOURCE_MAP_PATH}\")
 install(TARGETS ${dsi_library_name} ${gridmap_callout_library_name} DESTINATION $ENV{DEST_LIB_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 ###############################################################################
 
 cmake_minimum_required (VERSION 2.8)
-project (iRODS_DSI C)
+project (iRODS_DSI C CXX)
 set(GENERIC_LIB_VERSION "1.6.6")
 
 ##### Check ENV variables ######
@@ -106,9 +106,11 @@ add_library(${dsi_library_name} SHARED globus_gridftp_server_iRODS.c)
 add_library(${gridmap_callout_library_name} SHARED gridmap_iRODS_callout.c libirodsmap.c)
 
 set_target_properties(${dsi_library_name} PROPERTIES VERSION ${GENERIC_LIB_VERSION} )
+set_target_properties(${dsi_library_name} PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(${dsi_library_name} ${irods_link_obj_path})
 
 set_target_properties(${gridmap_callout_library_name} PROPERTIES LINK_FLAGS ${gridmap_callout_library_LINK_FLAGS} VERSION ${GENERIC_LIB_VERSION} )
+set_target_properties(${gridmap_callout_library_name} PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(${gridmap_callout_library_name} ${irods_link_obj_path})
 
 set(gridmap_callout_conf_name gridmap_iRODS_callout.conf)
@@ -116,6 +118,7 @@ set(gridmap_callout_conf_name gridmap_iRODS_callout.conf)
 set(testirodsmap_exe "testirodsmap")
 set(testirodsmap_exe_LINK_FLAGS "-ldl -lglobus_gss_assist -lstdc++")
 add_executable(${testirodsmap_exe} testirodsmap.c libirodsmap.c)
+set_target_properties(${testirodsmap_exe} PROPERTIES LINKER_LANGUAGE CXX)
 set_target_propertieS(${testirodsmap_exe} PROPERTIES LINK_FLAGS ${testirodsmap_exe_LINK_FLAGS})
 target_link_libraries(${testirodsmap_exe} ${irods_link_obj_path})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,14 +37,29 @@ if (DEFINED ENV{IRODS_PATH})
     if ($ENV{IRODS_PATH} STREQUAL "/usr")
         add_definitions(-DIRODS_HEADER_HPP)
         set(irods_include_path_list "$ENV{IRODS_PATH}/include/irods")
-        set(irods_link_obj_path "$ENV{IRODS_PATH}/lib/libRodsAPIs.a"
-                "-lrt"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libjansson.a"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_chrono.a"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_filesystem.a"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_regex.a"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_system.a"
-                "$ENV{IRODS_PATH}/lib/irods/externals/libboost_thread.a")
+        if (DEFINED ENV{IRODS_40_COMPAT})
+            set(irods_link_obj_path 
+                    "$ENV{IRODS_PATH}/lib/irods/libirods_client.so"
+                    "$ENV{IRODS_PATH}/lib/irods/libirods_client_api.so"
+                    "-lrt"
+                    "$ENV{IRODS_PATH}/lib/irods/libjansson.a"
+                    "$ENV{IRODS_PATH}/lib/irods/libboost_filesystem.a"
+                    "$ENV{IRODS_PATH}/lib/irods/libboost_regex.a"
+                    "$ENV{IRODS_PATH}/lib/irods/libboost_system.a"
+                    "$ENV{IRODS_PATH}/lib/irods/libboost_thread.a")
+        else()
+            set(irods_link_obj_path 
+                    "$ENV{IRODS_PATH}/lib/libirods_client.so"
+                    "$ENV{IRODS_PATH}/lib/libirods_client_api.so"
+                    "-lrt"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libjansson.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_chrono.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_filesystem.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_program_options.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_regex.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_system.a"
+                    "$ENV{IRODS_PATH}/lib/irods/externals/libboost_thread.a")
+        endif()
     else()
         set(irods_include_path_list "$ENV{IRODS_PATH}/lib/api/include"
                 "$ENV{IRODS_PATH}/lib/core/include"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 
 cmake_minimum_required (VERSION 2.8)
 project (iRODS_DSI C)
-set(GENERIC_LIB_VERSION "1.6.3")
+set(GENERIC_LIB_VERSION "1.6.6")
 
 ##### Check ENV variables ######
 if (DEFINED ENV{GLOBUS_LOCATION})

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ server package without recompiling it.
       * make clean && make
 
    The solution 'a' has the advantage of woorking even if you later recompile 
-   iRODS again. The solution 'b' is the same as solution 'a', but using irodssetup 
-   instead of make. The solution 'c' is faster to be implemented. 
+   iRODS again. The solution 'b' is the same as solution 'a', but using
+   irodssetup instead of make.  That makes the changes persist even after
+   irodssetup is re-run. The solution 'c' is faster to be implemented. 
 
 4) Install the module into the GLOBUS_LOCATION. To do this you will need write 
    permission for that directory:

--- a/README.md
+++ b/README.md
@@ -226,11 +226,26 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
   being mapped as a single argument and may for example add a mapping to an
   existing account, or create a new account.
 
-  To enable this feature, set the '$irodsDnCommand' environment variable in '/etc/gridftp.conf' to the name of the command to execute.  On the iRODS server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.  For example, to invoke a script called 'createUser', add:
+  To enable this feature, set the '$irodsDnCommand' environment variable in
+  '/etc/gridftp.conf' to the name of the command to execute.  On the iRODS
+  server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.
+  For example, to invoke a script called 'createUser', add:
 
         $irodsDnCommand "createUser"
 
-* There is also a command line utility to test the mapping lookups (and script execution) that would otherwise be done by the gridmap module.  This utility command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be invoked with the DN as a single argument.  The command would need to see the same environment variables as the gridmap module loaded into the GridFTP server - specifically, '$irodsEnvFile' pointing to the iRODS  environment and '$irodsDnCommand' setting the command to invoke if no mapping is found.  The 'testirodsmap' command also needs to have access to the server host certificate - and find it either through the default mechanisms used by Globus GSI or by explicitly setting the 'X509_USER_CERT' and 'X509_USER_KEY' environment variables.  (The easiest way is to run the command in the same environment as the Globus GridFTP server, i.e., under the root account).  For example, invoke the command with:
+* There is also a command line utility to test the mapping lookups (and script
+  execution) that would otherwise be done by the gridmap module.  This utility
+  command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be
+  invoked with the DN as a single argument.  The command would need to see the
+  same environment variables as the gridmap module loaded into the GridFTP
+  server - specifically, '$irodsEnvFile' pointing to the iRODS  environment and
+  '$irodsDnCommand' setting the command to invoke if no mapping is found.  The
+  'testirodsmap' command also needs to have access to the server host
+  certificate - and find it either through the default mechanisms used by
+  Globus GSI or by explicitly setting the 'X509_USER_CERT' and 'X509_USER_KEY'
+  environment variables.  (The easiest way is to run the command in the same
+  environment as the Globus GridFTP server, i.e., under the root account).  For
+  example, invoke the command with:
 
         export irodsDnCommand=createUser 
         export irodsEnvFile=/path/to/.irodsEnv

--- a/README.md
+++ b/README.md
@@ -174,39 +174,40 @@ required):
 Additional configuration
 --------------------------------
 1. If desired, change the default home directory by setting the homeDirPattern
-   environment variable in ````/etc/gridftp.conf````.  The pattern can reference up to
-   two strings with ````%s````, first gets substituted with the zone name, second with
-   the user name.  The default value is ````"/%s/home/%s"````, making the default
-   directory ````/<zone>/home/<username>````.
+   environment variable in ````/etc/gridftp.conf````.  The pattern can
+   reference up to two strings with ````%s````, first gets substituted with the
+   zone name, second with the user name.  The default value is
+   ````"/%s/home/%s"````, making the default directory
+   ````/<zone>/home/<username>````.
 
-Default configuration:
+   Default configuration:
 
        $homeDirPattern "/%s/home/%s"
 
-Example alternative configuration (defaulting to ````/<zone>/home````):
+   Example alternative configuration (defaulting to ````/<zone>/home````):
 
        $homeDirPattern "/%s/home"
 
 2. Optionally, turn on the feature that would make the DSI module authenticate
    as the rods admin user - but operate under the privileges of the target user.
 
-* Grant the GridFTP server access to the rods account:
+   * Grant the GridFTP server access to the rods account:
 
         $ iadmin aua rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
         $ iadmin lua rods
         rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
 
-* Make sure 'irodsUserName' is included in the '/path/to/.irodsEnv' file created above:
+   * Make sure 'irodsUserName' is included in the '/path/to/.irodsEnv' file created above:
 
         irodsUserName rods
 
-* Set the ````$irodsConnectAsAdmin````  environment variable in ````/etc/gridftp.conf```` to a non-empty value:
+   * Set the ````$irodsConnectAsAdmin````  environment variable in ````/etc/gridftp.conf```` to a non-empty value:
 
-        $irodsConnectAsAdmin "rods"
+       $irodsConnectAsAdmin "rods"
 
-  With all of this in place, it is no longer necessary to associate the DN of the server with each individual user - the server can now access user accounts through the rods account.
+   With all of this in place, it is no longer necessary to associate the DN of the server with each individual user - the server can now access user accounts through the rods account.
 
-  NOTE: this feature requires iRODS server at least 3.3 - GSI authentication with a proxy user breaks on iRODS 3.2 and earlier.
+   NOTE: this feature requires iRODS server at least 3.3 - GSI authentication with a proxy user breaks on iRODS 3.2 and earlier.
 
 3. Optionally, use a Globus gridmap callout module to map subject DNs to iRODS
    user names based on the existing mappings in iRODS (in r_user_auth table).
@@ -215,41 +216,43 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
    The gridmap callout configuration file gets already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
 
-* To activate the module, set the '$GSI_AUTH_CONF' environment variable in '/etc/gridftp.conf' to point to the configuration file - already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
+   * To activate the module, set the '$GSI_AUTH_CONF' environment variable in '/etc/gridftp.conf' to point to the configuration file - already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
 
-        $GSI_AUTHZ_CONF /etc/grid-security/gridmap_iRODS_callout.conf
+       $GSI_AUTHZ_CONF /etc/grid-security/gridmap_iRODS_callout.conf
 
-* Note that in order for this module to work, the server certificate DN must be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
+   * Note that in order for this module to work, the server certificate DN must
+     be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
 
-* This module also supports invoking an iRODS server-side command with iexec in
-  case the DN does not have a mapping yet.  The command would receive the DN
-  being mapped as a single argument and may for example add a mapping to an
-  existing account, or create a new account.
+   * This module also supports invoking an iRODS server-side command with iexec
+     in case the DN does not have a mapping yet.  The command would receive the
+     DN being mapped as a single argument and may for example add a mapping to
+     an existing account, or create a new account.
 
-  To enable this feature, set the '$irodsDnCommand' environment variable in
-  '/etc/gridftp.conf' to the name of the command to execute.  On the iRODS
-  server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.
-  For example, to invoke a script called 'createUser', add:
+   To enable this feature, set the '$irodsDnCommand' environment variable in
+   '/etc/gridftp.conf' to the name of the command to execute.  On the iRODS
+   server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.
+   For example, to invoke a script called 'createUser', add:
 
-        $irodsDnCommand "createUser"
+       $irodsDnCommand "createUser"
 
-* There is also a command line utility to test the mapping lookups (and script
-  execution) that would otherwise be done by the gridmap module.  This utility
-  command gets installed into '$DEST_BIN_DIR/testirodsmap' and should be
-  invoked with the DN as a single argument.  The command would need to see the
-  same environment variables as the gridmap module loaded into the GridFTP
-  server - specifically, '$irodsEnvFile' pointing to the iRODS  environment and
-  '$irodsDnCommand' setting the command to invoke if no mapping is found.  The
-  'testirodsmap' command also needs to have access to the server host
-  certificate - and find it either through the default mechanisms used by
-  Globus GSI or by explicitly setting the 'X509_USER_CERT' and 'X509_USER_KEY'
-  environment variables.  (The easiest way is to run the command in the same
-  environment as the Globus GridFTP server, i.e., under the root account).  For
-  example, invoke the command with:
+   * There is also a command line utility to test the mapping lookups (and
+     script execution) that would otherwise be done by the gridmap module.
+     This utility command gets installed into '$DEST_BIN_DIR/testirodsmap' and
+     should be invoked with the DN as a single argument.  The command would
+     need to see the same environment variables as the gridmap module loaded
+     into the GridFTP server - specifically, '$irodsEnvFile' pointing to the
+     iRODS  environment and '$irodsDnCommand' setting the command to invoke if
+     no mapping is found.  The 'testirodsmap' command also needs to have access
+     to the server host certificate - and find it either through the default
+     mechanisms used by Globus GSI or by explicitly setting the
+     'X509_USER_CERT' and 'X509_USER_KEY' environment variables.  
+     (The easiest way is to run the command in the same environment as the
+     Globus GridFTP server, i.e., under the root account).  For example, invoke
+     the command with:
 
-        export irodsDnCommand=createUser 
-        export irodsEnvFile=/path/to/.irodsEnv
-        $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
+         export irodsDnCommand=createUser 
+         export irodsEnvFile=/path/to/.irodsEnv
+         $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 
 4. When deploying with iRODS 4, it is necessary to preload the DSI library into
    the GridFTP server binary, so that the symbols exported by the library are

--- a/README.md
+++ b/README.md
@@ -48,12 +48,22 @@ server package without recompiling it.
    - GLOBUS_LOCATION --> path to the Globus installation (if you have installed
      the Globus GridFTP Server from packages, use '/usr')
    - IRODS_PATH --> path to the iRODS installation
-   - FLAVOR --> (optional) flavors of the Globus packages which are already installed[a] 
-   - DEST_LIB_DIR --> (optional) path to the folder in which the library will be copied
-   - DEST_BIN_DIR --> (optional) path to the folder in which binary executables (auxilliary tools) will be copied
-   - DEST_ETC_DIR --> (optional) path to the folder in which configuration files will be copied
+   - FLAVOR --> (optional) flavors of the Globus packages which are already
+     installed[a] 
+   - DEST_LIB_DIR --> (optional) path to the folder in which the library will
+     be copied
+   - DEST_BIN_DIR --> (optional) path to the folder in which binary executables
+     (auxilliary tools) will be copied
+   - DEST_ETC_DIR --> (optional) path to the folder in which configuration
+     files will be copied
    - RESOURCE_MAP_PATH --> (optional) path to the folder containing the 
      "irodsResourceMap.conf" file (see step 4 of section "Configure and run") 
+   - IRODS_40_COMPAT --> (optional) Use iRODS 4.0.x compatible library file
+     locations.  (Use for iRODS 4.0.x only, not needed for iRODS 4.1.+).
+
+   Note: comment out any variables not set (as leaving them set to a blank
+   value would prevent CMake from constructing correct default values for
+   variables that are optional).
 
    [a] This depends on your globus installation. You will probably not need it. 
        In case of error, possible flavors are:

--- a/README.md
+++ b/README.md
@@ -122,31 +122,31 @@ required):
 
 1. Modify '/etc/gridftp.conf' adding:
 
-      $GRIDMAP "/path/to/grid-mapfile"  
-      $irodsEnvFile "/path/to/.irodsEnv" 
-      load_dsi_module iRODS 
-      auth_level 4
+        $GRIDMAP "/path/to/grid-mapfile"  
+        $irodsEnvFile "/path/to/.irodsEnv" 
+        load_dsi_module iRODS 
+        auth_level 4
 
    where '/path/to/.irodsEnv' contains at least the lines:
 
-       irodsHost 'your.irods.server'
-       irodsPort 'port'
-       irodsZone 'zone'
-       irodsAuthScheme 'GSI'
+        irodsHost 'your.irods.server'
+        irodsPort 'port'
+        irodsZone 'zone'
+        irodsAuthScheme 'GSI'
 
 
 2. In /etc/grid-security/grid-mapfile associate the DNs to the irods usernames, 
    for example:
 
-   $ grep mrossi /etc/grid-security/grid-mapfile
-   "/C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi" mrossi
+        $ grep mrossi /etc/grid-security/grid-mapfile
+        "/C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi" mrossi
 
 3. In the iCAT associate the irods usernames to the user DNs as well as to 
    the gridftp server DN, for example:
 
-   $ iadmin lua | grep mrossi
-   mrossi /C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi
-   mrossi /C=IT/O=INFN/OU=Host/L=CINECA-SAP/CN=fec03.cineca.it
+        $ iadmin lua | grep mrossi
+        mrossi /C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi
+        mrossi /C=IT/O=INFN/OU=Host/L=CINECA-SAP/CN=fec03.cineca.it
 
 4. It is possible to specify a policy to manage more than one iRODS resource.
    The DSI module looks for a file called 'irodsresourcemap.conf' (step 1 of the
@@ -154,9 +154,9 @@ required):
    resource has to be used when creating a file in a particular iRODS path.
    For example:
    
-   $ cat irodsResourceMap.conf 
-   /CINECA01/home/cin_staff/rmucci00;resc-repl
-   /CINECA01/home/cin_staff/mrossi;resc-repl
+        $ cat irodsResourceMap.conf 
+        /CINECA01/home/cin_staff/rmucci00;resc-repl
+        /CINECA01/home/cin_staff/mrossi;resc-repl
 
    If none of the listed paths is matched, the iRODS default resource is used. 
 
@@ -164,11 +164,11 @@ required):
    and pid files where the user who is running the server has the required 
    ownership and run the server with:
 
-   $ /etc/init.d/globus-gridftp-server start
+        $ /etc/init.d/globus-gridftp-server start
    
    in alternative you can run the server with: 
    
-   $ /usr/sbin/globus-gridftp-server -S -d ALL -c $WRKDIR/gridftp.conf
+        $ /usr/sbin/globus-gridftp-server -S -d ALL -c $WRKDIR/gridftp.conf
 
 
 Additional configuration
@@ -177,33 +177,32 @@ Additional configuration
    environment variable in ````/etc/gridftp.conf````.  The pattern can
    reference up to two strings with ````%s````, first gets substituted with the
    zone name, second with the user name.  The default value is
-   ````"/%s/home/%s"````, making the default directory
-   ````/<zone>/home/<username>````.
+   ````"/%s/home/%s"````, making the default directory ````/<zone>/home/<username>````.
 
    Default configuration:
 
-       $homeDirPattern "/%s/home/%s"
+        $homeDirPattern "/%s/home/%s"
 
    Example alternative configuration (defaulting to ````/<zone>/home````):
 
-       $homeDirPattern "/%s/home"
+        $homeDirPattern "/%s/home"
 
 2. Optionally, turn on the feature that would make the DSI module authenticate
    as the rods admin user - but operate under the privileges of the target user.
 
    * Grant the GridFTP server access to the rods account:
 
-        $ iadmin aua rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
-        $ iadmin lua rods
-        rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
+            $ iadmin aua rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
+            $ iadmin lua rods
+            rods /C=TW/O=AP/OU=GRID/CN=irodsdev.canterbury.ac.nz
 
    * Make sure 'irodsUserName' is included in the '/path/to/.irodsEnv' file created above:
 
-        irodsUserName rods
+            irodsUserName rods
 
    * Set the ````$irodsConnectAsAdmin````  environment variable in ````/etc/gridftp.conf```` to a non-empty value:
 
-       $irodsConnectAsAdmin "rods"
+            $irodsConnectAsAdmin "rods"
 
    With all of this in place, it is no longer necessary to associate the DN of the server with each individual user - the server can now access user accounts through the rods account.
 
@@ -218,7 +217,7 @@ Additional configuration
 
    * To activate the module, set the '$GSI_AUTH_CONF' environment variable in '/etc/gridftp.conf' to point to the configuration file - already created as '$DEST_ETC_DIR/gridmap_iRODS_callout.conf'.
 
-       $GSI_AUTHZ_CONF /etc/grid-security/gridmap_iRODS_callout.conf
+            $GSI_AUTHZ_CONF /etc/grid-security/gridmap_iRODS_callout.conf
 
    * Note that in order for this module to work, the server certificate DN must
      be authorized to connect as a rodsAdmin user (e.g., the 'rods' user).
@@ -233,7 +232,7 @@ Additional configuration
    server, the command should be installed in '$IRODS_HOME/server/bin/cmd/'.
    For example, to invoke a script called 'createUser', add:
 
-       $irodsDnCommand "createUser"
+        $irodsDnCommand "createUser"
 
    * There is also a command line utility to test the mapping lookups (and
      script execution) that would otherwise be done by the gridmap module.
@@ -250,9 +249,9 @@ Additional configuration
      Globus GridFTP server, i.e., under the root account).  For example, invoke
      the command with:
 
-         export irodsDnCommand=createUser 
-         export irodsEnvFile=/path/to/.irodsEnv
-         $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
+            export irodsDnCommand=createUser 
+            export irodsEnvFile=/path/to/.irodsEnv
+            $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 
 4. When deploying with iRODS 4, it is necessary to preload the DSI library into
    the GridFTP server binary, so that the symbols exported by the library are

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Configure and run
 In order to run the server as an unprivileged user (root privileges are not 
 required):
 
-1) Modify '/etc/gridftp.conf' adding:
+1. Modify '/etc/gridftp.conf' adding:
 
       $GRIDMAP "/path/to/grid-mapfile"  
       $irodsEnvFile "/path/to/.irodsEnv" 
@@ -135,20 +135,20 @@ required):
        irodsAuthScheme 'GSI'
 
 
-2) In /etc/grid-security/grid-mapfile associate the DNs to the irods usernames, 
+2. In /etc/grid-security/grid-mapfile associate the DNs to the irods usernames, 
    for example:
 
    $ grep mrossi /etc/grid-security/grid-mapfile
    "/C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi" mrossi
 
-3) In the iCAT associate the irods usernames to the user DNs as well as to 
+3. In the iCAT associate the irods usernames to the user DNs as well as to 
    the gridftp server DN, for example:
 
    $ iadmin lua | grep mrossi
    mrossi /C=IT/O=INFN/OU=Personal Certificate/L=CINECA-SAP/CN=Mario Rossi
    mrossi /C=IT/O=INFN/OU=Host/L=CINECA-SAP/CN=fec03.cineca.it
 
-4) It is possible to specify a policy to manage more than one iRODS resource.
+4. It is possible to specify a policy to manage more than one iRODS resource.
    The DSI module looks for a file called 'irodsresourcemap.conf' (step 1 of the
    Installation paragraph). In that file it is possible to specify which iRODS 
    resource has to be used when creating a file in a particular iRODS path.
@@ -160,7 +160,7 @@ required):
 
    If none of the listed paths is matched, the iRODS default resource is used. 
 
-5) Modify the globus-gridftp-server script in /etc/init.d in order to create log
+5. Modify the globus-gridftp-server script in /etc/init.d in order to create log
    and pid files where the user who is running the server has the required 
    ownership and run the server with:
 
@@ -173,7 +173,7 @@ required):
 
 Additional configuration
 --------------------------------
-1) If desired, change the default home directory by setting the homeDirPattern
+1. If desired, change the default home directory by setting the homeDirPattern
    environment variable in ````/etc/gridftp.conf````.  The pattern can reference up to
    two strings with ````%s````, first gets substituted with the zone name, second with
    the user name.  The default value is ````"/%s/home/%s"````, making the default
@@ -187,7 +187,7 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
        $homeDirPattern "/%s/home"
 
-2) Optionally, turn on the feature that would make the DSI module authenticate
+2. Optionally, turn on the feature that would make the DSI module authenticate
    as the rods admin user - but operate under the privileges of the target user.
 
 * Grant the GridFTP server access to the rods account:
@@ -208,7 +208,7 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
 
   NOTE: this feature requires iRODS server at least 3.3 - GSI authentication with a proxy user breaks on iRODS 3.2 and earlier.
 
-3) Optionally, use a Globus gridmap callout module to map subject DNs to iRODS
+3. Optionally, use a Globus gridmap callout module to map subject DNs to iRODS
    user names based on the existing mappings in iRODS (in r_user_auth table).
    Configuring this feature eliminates the need for a local grid map file - all
    user mappings can be done through the callout function.
@@ -251,20 +251,20 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
         export irodsEnvFile=/path/to/.irodsEnv
         $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 
-4) When deploying with iRODS 4, it is necessary to preload the DSI library into
+4. When deploying with iRODS 4, it is necessary to preload the DSI library into
    the GridFTP server binary, so that the symbols exported by the library are
    visible.  Otherwise, when iRODS 4 tries loading plugins (including basic
    network and authentication plugins), the plugins would fail to load (as the
    plugins are not explicitly declaring a dependency on the runtime symbols).
 
    To preload the library, you need to set the LD_PRELOAD variable to
-   '$DEST_LIB_DIR/libglobus_gridftp_server_iRODS.so' (or
-   '$DEST_LIB_DIR/libglobus_gridftp_server_iRODS_$FLAVOR.so') in the
+   ````$DEST_LIB_DIR/libglobus_gridftp_server_iRODS.so```` (or
+   ````$DEST_LIB_DIR/libglobus_gridftp_server_iRODS_$FLAVOR.so````) in the
    environment from which the GridFTP server is started (i.e., it is not enough
    to set it in /etc/gridftp.conf).
 
-   For example, modify (or create) '/etc/sysconfig/globus-gridftp-server' and
-   add the lines:
+   For example, modify (or create) ````/etc/sysconfig/globus-gridftp-server````
+   and add the lines:
 
         LD_PRELOAD="$LD_PRELOAD:/opt/iRODS_DSI/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
         export LD_PRELOAD

--- a/README.md
+++ b/README.md
@@ -282,8 +282,13 @@ Additional configuration
    For example, modify (or create) ````/etc/sysconfig/globus-gridftp-server````
    and add the lines:
 
-        LD_PRELOAD="$LD_PRELOAD:/opt/iRODS_DSI/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
+        LD_PRELOAD="$LD_PRELOAD:/usr/lib64/libglobus_gridftp_server.so:/opt/iRODS_DSI/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
         export LD_PRELOAD
+
+   Note: it is necessary to load the GridFTP server library alongside the DSI
+   library (which depends on symbols provided by the GridFTP server library).
+   Otherwise, any command invocation in that environment fails with unresolved
+   symbol errors.
 
 Logrotate
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -251,6 +251,24 @@ Example alternative configuration (defaulting to ````/<zone>/home````):
         export irodsEnvFile=/path/to/.irodsEnv
         $DEST_BIN_DIR/testirodsmap "/C=XX/O=YYY/CN=Example User"
 
+4) When deploying with iRODS 4, it is necessary to preload the DSI library into
+   the GridFTP server binary, so that the symbols exported by the library are
+   visible.  Otherwise, when iRODS 4 tries loading plugins (including basic
+   network and authentication plugins), the plugins would fail to load (as the
+   plugins are not explicitly declaring a dependency on the runtime symbols).
+
+   To preload the library, you need to set the LD_PRELOAD variable to
+   '$DEST_LIB_DIR/libglobus_gridftp_server_iRODS.so' (or
+   '$DEST_LIB_DIR/libglobus_gridftp_server_iRODS_$FLAVOR.so') in the
+   environment from which the GridFTP server is started (i.e., it is not enough
+   to set it in /etc/gridftp.conf).
+
+   For example, modify (or create) '/etc/sysconfig/globus-gridftp-server' and
+   add the lines:
+
+        LD_PRELOAD="$LD_PRELOAD:/opt/iRODS_DSI/iRODS_DSI/libglobus_gridftp_server_iRODS.so"
+        export LD_PRELOAD
+
 Logrotate
 --------------------------------
 If you use -d ALL as in the example, please, be aware that the log files could 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Installation
 The installation is quite simple: it is possible to use the official gridftp 
 server package without recompiling it.
 
-1) Set the following environment variables (it can be done editing and renaming 
+1. Set the following environment variables (it can be done editing and renaming 
    the "setup.sh.template" file):
 
    - GLOBUS_LOCATION --> path to the Globus installation (if you have installed
@@ -55,62 +55,66 @@ server package without recompiling it.
    - RESOURCE_MAP_PATH --> (optional) path to the folder containing the 
      "irodsResourceMap.conf" file (see step 4 of section "Configure and run") 
 
-[a] This depends on your globus installation. You will probably not need it. 
-   In case of error, possible flavors are:
-   FLAVOR=gcc64dbg
-   or
-   FLAVOR=gcc64dbgpthr
-   You can access this information with gpt-query. 
-   Anyway, if the flavor is not correct, the error running the server should help.
+   [a] This depends on your globus installation. You will probably not need it. 
+       In case of error, possible flavors are:
+       
+            FLAVOR=gcc64dbg
+            
+       or
+       
+            FLAVOR=gcc64dbgpthr
+            
+       You can access this information with gpt-query. 
+       Anyway, if the flavor is not correct, the error returned when attempting to run the server should help.
 
-2) Run cmake:
+2. Run cmake:
    
-   $ cmake (path to CMakeFile.txt)
+        $ cmake (path to CMakeFile.txt)
 
-3) Compile the module:
+3. Compile the module:
 
-   $ make
+        $ make
 
    An error like:
-   ${IRODS_PATH}/lib/core/obj/libRodsAPIs.a(clientLogin.o):
-   relocation R_X86_64_32 against `.bss` can not be used when making a
-   shared object; recompile with -fPIC
+   
+        ${IRODS_PATH}/lib/core/obj/libRodsAPIs.a(clientLogin.o):
+        relocation R_X86_64_32 against `.bss` can not be used when making a
+        shared object; recompile with -fPIC
 
    usually happens on x86_64 systems. In order to solve it, recompile iRODS with 
    the mentioned flag, -fPIC. This can be done in three alternative ways:
 
-   a) in ${IRODS_PATH} modify
-      * clients/icommands/Makefile
-      * lib/Makefile
-      * server/Makefile
-      adding the following line:
-      CFLAGS +=  -fPIC
-      * make clean && make
+   a) In ${IRODS_PATH} modify the CFLAGS definition in the Makefiles
+      * Edit ````clients/icommands/Makefile````, ````lib/Makefile````, and ````server/Makefile````, 
+        adding the following line:
+        
+            CFLAGS +=  -fPIC
+          
+      * Run: ````make clean && make````
 
-   b) in ${IRODS_PATH} modify CCFLAGS variable:  
-      * config/irods.config:
-        $CCFLAGS = '-fPIC'; 
-      * config/platform.mk:
-        CCFLAGS=-fPIC
-      * irodssetup
+   b) In ````${IRODS_PATH}```` modify the ````CCFLAGS```` variable:  
+      * In ````config/irods.config````, set: ````$CCFLAGS = '-fPIC';````
+      * In ````config/platform.mk````, set: ````CCFLAGS=-fPIC````
+      * Run: ````irodssetup````
 
-   c) in ${IRODS_PATH}:
-      * export CFLAGS="$CFLAGS -fPIC"
-      * make clean && make
+   c) In ${IRODS_PATH}, run:
+   
+        export CFLAGS="$CFLAGS -fPIC"
+        make clean && make
 
    The solution 'a' has the advantage of woorking even if you later recompile 
    iRODS again. The solution 'b' is the same as solution 'a', but using
    irodssetup instead of make.  That makes the changes persist even after
    irodssetup is re-run. The solution 'c' is faster to be implemented. 
 
-4) Install the module into the GLOBUS_LOCATION. To do this you will need write 
+4. Install the module into the GLOBUS_LOCATION. To do this you will need write 
    permission for that directory:
 
-   $ make install 
+        $ make install 
 
    If you have installed the Globus GridFTP Server from packages:
 
-   $ sudo make install
+        $ sudo make install
   
 
 

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -25,7 +25,11 @@
 
 
 #include "globus_gridftp_server.h"
-#include "rodsClient.h"
+#ifdef IRODS_HEADER_HPP
+  #include "rodsClient.hpp"
+#else
+  #include "rodsClient.h"
+#endif
 #include <stdio.h> 
 #include <time.h>
 #include <unistd.h>
@@ -631,8 +635,11 @@ globus_l_gfs_iRODS_start(
         result = GlobusGFSErrorGeneric(err_str); 
         goto connect_error;
     }
-    
+#ifdef IRODS_HEADER_HPP
+    status = clientLogin(iRODS_handle->conn, NULL, NULL);
+#else
     status = clientLogin(iRODS_handle->conn);
+#endif
     if (status != 0) {
         result = globus_l_gfs_iRODS_make_error("\'clientLogin\' failed.", status);
         goto error;

--- a/libirodsmap.c
+++ b/libirodsmap.c
@@ -8,7 +8,11 @@
  *
  */
 
-#include "rodsClient.h"
+#ifdef IRODS_HEADER_HPP
+  #include "rodsClient.hpp"
+#else
+  #include "rodsClient.h"
+#endif
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>
@@ -35,7 +39,11 @@ int libirodsmap_connect(rcComm_t ** rcComm_out) {
     };
     libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_connect: connected to iRODS server (%s:%d)\n", myRodsEnv.rodsHost, myRodsEnv.rodsPort);
 
+#ifdef IRODS_HEADER_HPP
+    rc = clientLogin(rcComm, NULL, NULL);
+#else
     rc = clientLogin(rcComm);
+#endif
     if (rc != 0) {
         libirodsmap_log(IRODSMAP_LOG_ERR,"libirodsmap_connect: clientLogin failed: %s%d\n", "", rc);
         goto connect_error;

--- a/libirodsmap.c
+++ b/libirodsmap.c
@@ -9,7 +9,6 @@
  */
 
 #include "rodsClient.h"
-//#include "rodsGenQueryNames.h"
 #include <stdio.h>
 #include <time.h>
 #include <unistd.h>

--- a/libirodsmap.c
+++ b/libirodsmap.c
@@ -32,9 +32,10 @@ int libirodsmap_connect(rcComm_t ** rcComm_out) {
         goto connect_error;
     };
 
+    libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_connect: attempting rcConnect to %s:%d\n", myRodsEnv.rodsHost, myRodsEnv.rodsPort);
     rcComm = rcConnect(myRodsEnv.rodsHost, myRodsEnv.rodsPort, myRodsEnv.rodsUserName, myRodsEnv.rodsZone, 0, &errMsg);
     if (rcComm == NULL) {
-        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_connect: rcConnect failed ignore %s\n", errMsg.msg, 0);
+        libirodsmap_log(IRODSMAP_LOG_ERR, "libirodsmap_connect: rcConnect failed (%s)\n", errMsg.msg, 0);
         goto connect_error;
     };
     libirodsmap_log(IRODSMAP_LOG_DEBUG, "libirodsmap_connect: connected to iRODS server (%s:%d)\n", myRodsEnv.rodsHost, myRodsEnv.rodsPort);

--- a/setup.sh.template
+++ b/setup.sh.template
@@ -19,3 +19,6 @@ export DEST_ETC_DIR=""        #(optional) path to the folder in which configurat
 
 export RESOURCE_MAP_PATH=""   #(optional) path to the folder containing the 
                               #"irodsResourceMap.conf" file (see step 4 of section "Configure and run") 
+
+#export IRODS_40_COMPAT=""    #(optional) Use compatible library locations for
+                              #iRODS 4.0.x only (not needed for iRODS 4.1+).


### PR DESCRIPTION
Hi Roberto,

These are the iRODS 4 fixes discussed in #7.

This version compiles both with 3.3.1 and 4.1(DEV).

On my test system, it needs iRODS 3.3.1 manually tweaked with -fPIC.

For iRODS 4, I had to manually tweak libjansson to compile with -fPIC (mimicking as if https://github.com/irods/irods/pull/2623 was already merged).

Please let me know if it's working for you all fine.

Cheers,
Vlad

PS: I also included a commit to bring up the version string in CMakeList.txt in sync with the tagged version.  If you make another release, please remember to update that file too.

PPS: I overlooked your iRODS 4 branch before I started this work, sorry about the extra work.  The find packages refactoring looks interesting - hope it won't be too much hassle to fit onto the changes I made to CMakeList.txt...