### PR TITLE
README.md: iRODS4: use MD5 for CKSM to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,14 @@ Additional configuration
    Otherwise, any command invocation in that environment fails with unresolved
    symbol errors.
 
+   Also, in order for GridFTP CKSM (checksum) command to work (and interoperate
+   with Globus.org), it is necessary to configure iRODS to use MD5 checksums
+   (iRODS 4 otherwise defaults to SHA-256).  Edit ````/etc/irods/server.config````
+   and set:
+
+        default_hash_scheme MD5
+
+
 Logrotate
 --------------------------------
 If you use -d ALL as in the example, please, be aware that the log files could 


### PR DESCRIPTION
Hi Roberto,

I ran into an issue where Globus.org would fail at the file verification stage, failing to parse the output of CKSM:

````
Globus had an unexpected failure. Please contact support@globus.org

fxp: fxp/parse.cpp:28: std::string fxp_parse_md5_checksum_response(conn::Response*): Assertion `isalnum(ret[i])' failed.
Exited due to signal 6 (SIGABRT)
````

I saw in GridFTP server log that the syntax returned an base64-encoded SHA2 hash:

````
[24929] Tue Jun  2 14:26:07 2015 :: smtp.globusonline.org:33480: [SERVER]: 226 Transfer Complete.
[24929] Tue Jun  2 14:26:07 2015 :: smtp.globusonline.org:33480: [CLIENT]: CKSM MD5 0 -1 ~/Ducklings_Beware.jpg
[24929] Tue Jun  2 14:26:07 2015 :: iRODS: rcDataObjChksum: collection=/BeSTGRID-I4-DEV/home/vlad/Ducklings_Beware.jpg
[24929] Tue Jun  2 14:26:07 2015 :: smtp.globusonline.org:33480: [SERVER]: 213 sha2:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
````

while the default MD5 hash would also be just hex-dumped:

````
[13001] Tue Jun  2 15:43:59 2015 :: smtp.globusonline.org:54748: [CLIENT]: CKSM MD5 0 -1 ~/Ducklings_Beware.jpg
[13001] Tue Jun  2 15:43:59 2015 :: iRODS: rcDataObjChksum: collection=/BeSTGRID-DEV/home/vladimir.mencl/Ducklings_Beware.jpg
[13001] Tue Jun  2 15:43:59 2015 :: smtp.globusonline.org:54748: [SERVER]: 213 4cfb2402030bf306e5aa406f34df5f70
````

I have added instructions to README.md to change the iRODS hash scheme to MD5 - courtesy

https://groups.google.com/forum/#!searchin/irod-chat/sha$20md5|sort:date/irod-chat/ijGHveNQ9go/CbSg5ZmbIYAJ

Cheers,
Vlad


