### PR TITLE
Support for setting a default resource + minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ if (DEFINED ENV{IRODS_PATH})
                     "$ENV{IRODS_PATH}/lib/libirods_client.so"
                     "$ENV{IRODS_PATH}/lib/libirods_client_api.so"
                     "-lrt"
+                    "-lpthread"
                     "$ENV{IRODS_PATH}/lib/irods/externals/libjansson.a"
                     "$ENV{IRODS_PATH}/lib/irods/externals/libboost_chrono.a"
                     "$ENV{IRODS_PATH}/lib/irods/externals/libboost_filesystem.a"

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -54,6 +54,7 @@
 #define IRODS_CONNECT_AS_ADMIN "irodsConnectAsAdmin"
 
 static int                              iRODS_l_dev_wrapper = 10;
+/* structure and global variable for holding pointer to the (last) selected resource mapping */
 struct iRODS_Resource
 {
       char * path;
@@ -221,7 +222,12 @@ iRODS_getResource(
                 }
                 globus_gfs_log_message(GLOBUS_GFS_LOG_INFO, "iRODS: Resource found in %s: destinationPath = %s, iRODS resource = %s.\n", filename, destinationPath, iRODS_res);
                 
+                /* store the mapping in the global pointers in iRODS_Resource_struct - duplicating the string value.
+                 * Free any previously stored (duplicated) string pointer first!
+                 */
+                if (iRODS_Resource_struct.resource != NULL) { free(iRODS_Resource_struct.resource); };
                 iRODS_Resource_struct.resource =  strdup(iRODS_res); 
+                if (iRODS_Resource_struct.path != NULL) { free(iRODS_Resource_struct.path); };
                 iRODS_Resource_struct.path = strdup(path_Read);
                 break;
             }

--- a/globus_gridftp_server_iRODS.c
+++ b/globus_gridftp_server_iRODS.c
@@ -483,6 +483,7 @@ typedef struct globus_l_gfs_iRODS_handle_s
     int                                 port;
     
     char *                              zone;
+    char *                              defResource;
     char *                              user;
     char *                              domain; 
     
@@ -600,6 +601,10 @@ globus_l_gfs_iRODS_start(
     iRODS_handle->hostname = strdup(myRodsEnv.rodsHost);
     iRODS_handle->port = myRodsEnv.rodsPort;
     iRODS_handle->zone = strdup(myRodsEnv.rodsZone);
+    // copy also the default resource if it is set
+    if (strlen(myRodsEnv.rodsDefResource) > 0 ) {
+        iRODS_handle->defResource = strdup(myRodsEnv.rodsDefResource);
+    };
     iRODS_handle->user = iRODS_getUserName(session_info->subject); //iRODS usernmae
     user_name = strdup(session_info->username); //Globus user name
     
@@ -960,10 +965,13 @@ globus_l_gfs_iRODS_recv(
     bzero (&dataObjInp, sizeof (dataObjInp));
     rstrcpy (dataObjInp.objPath, collection, MAX_NAME_LEN);
     dataObjInp.openFlags = flags; 
+    // give priority to explicit resource mapping, otherwise use default resource if set
     if (iRODS_Resource_struct.resource != NULL)
     {
         addKeyVal (&dataObjInp.condInput, RESC_NAME_KW, iRODS_Resource_struct.resource);
-    }
+    } else if (iRODS_handle->defResource != NULL ) {
+        addKeyVal (&dataObjInp.condInput, RESC_NAME_KW, iRODS_handle->defResource);
+    };
     iRODS_handle->fd = rcDataObjOpen (iRODS_handle->conn, &dataObjInp);
     if (iRODS_handle->fd >= 0) {
         globus_gfs_log_message(GLOBUS_GFS_LOG_INFO,"iRODS: Open existing object: %s.\n", collection);
@@ -976,10 +984,14 @@ globus_l_gfs_iRODS_recv(
         rstrcpy (dataObjInp.objPath, collection, MAX_NAME_LEN);
         dataObjInp.dataSize = 0;
         addKeyVal (&dataObjInp.condInput, FORCE_FLAG_KW, "");
+        // give priority to explicit resource mapping, otherwise use default resource if set
         if (iRODS_Resource_struct.resource != NULL)
         {
             addKeyVal (&dataObjInp.condInput, DEST_RESC_NAME_KW, iRODS_Resource_struct.resource);
             globus_gfs_log_message(GLOBUS_GFS_LOG_INFO,"iRODS: Creating file with resource: %s\n", iRODS_Resource_struct.resource);
+        } else if (iRODS_handle->defResource != NULL ) {
+            addKeyVal (&dataObjInp.condInput, DEST_RESC_NAME_KW, iRODS_handle->defResource);
+            globus_gfs_log_message(GLOBUS_GFS_LOG_INFO,"iRODS: Creating file with default resource: %s\n", iRODS_handle->defResource);
         }
         iRODS_handle->fd = rcDataObjCreate (iRODS_handle->conn, &dataObjInp);
         if (iRODS_handle->fd < 0) {
@@ -1078,6 +1090,11 @@ globus_l_gfs_iRODS_send(
     
     bzero (&dataObjInp, sizeof (dataObjInp));
     rstrcpy (dataObjInp.objPath, collection, MAX_NAME_LEN);
+    // if we have a default resource set, open the file from this resource
+    if (iRODS_handle->defResource != NULL ) {
+        addKeyVal (&dataObjInp.condInput, RESC_NAME_KW, iRODS_handle->defResource);
+        globus_gfs_log_message(GLOBUS_GFS_LOG_INFO,"iRODS: Retrieving file from default resource: %s\n", iRODS_handle->defResource);
+    };
     iRODS_handle->fd = rcDataObjOpen (iRODS_handle->conn, &dataObjInp);
     
     if (iRODS_handle->fd < 0) {


### PR DESCRIPTION
Hi Roberto,

I've added some code to pass the default resource from the getRodsEnv output to the rcDataObjOpen calls (when the resource mapping does not have its say).

And I've also fixed a minor issue with building against iRODS 4.1 and fixed a memory leak I spotted...

Please let me know if you're happy to merge this in.

Cheers,
Vlad