### PR TITLE
Some updates for centos 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The module can be loaded by the GridFTP server at start-up time through a specif
 
 Prerequisites
 --------------------------------
-- CMake 2.7 or higher
+- CMake 2.7 or higher (part of irods-externals in iRODS 4.2.X)
 
 - iRODS with the Development Tools and Runtime Libraries packages: follow the instructions at https://packages.irods.org/ to add the iRODS repository to your package manager. Installation instructions can be found at https://irods.org/download/
 
@@ -36,7 +36,8 @@ Prerequisites
 
 	Centos:
 	```
-	sudo yum install 'irods-externals*
+	sudo yum -y install irods-devel
+	sudo yum install irods-externals-clang3.8-0.x86_64
 	```
 
 - Globus and other packages:
@@ -55,11 +56,11 @@ Prerequisites
 	```
 	Centos:
 	```
-	sudo yum install -y globus-gridftp-server-progs globus-gass-copy-progs libglobus-gss-assist-dev
+	sudo yum install -y globus-gridftp-server-progs globus-gass-copy-progs
 	sudo yum install -y globus-common-devel globus-gridftp-server-devel   globus-gridmap-callout-error-devel
 	sudo yum install -y libcurl-devel
 	sudo yum install -y git
-	sudo yum install -y g++
+	sudo yum install -y gcc-c++
 	sudo yum install -y globus-gsi-cert-utils-progs
 	sudo yum install -y globus-proxy-utils
 	```
@@ -91,6 +92,10 @@ Building iRODS DSI with CMake
 	In Ubuntu you may need to set up C_INCLUDE_PATH so that the globus_config.h header can be found.
 	```
 	export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu/globus
+	```
+	or
+	```
+	export C_INCLUDE_PATH=/usr/include/globus
 	```
 
 	If you are building for iRODS 4.2, set the IRODS_42_COMPAT environment variable to true.


### PR DESCRIPTION
**Dependencies**
No package irods-externals available.
	—> irods externals are installed when you install an iRODS iCAT enabled server
```
	ls /opt/irods-externals/
avro1.7.7-0  boost1.60.0-0  clang-runtime3.8-0  jansson2.7-0  libarchive3.1.2-0  zeromq4-14.1.3-0
```

No package libglobus-gss-assist-dev available.

No package g++ available.
	—> `sudo yum install -y gcc-c++`

No cmake 3:
	`yum -y install irods-externals-cmake3.5.2-0`

No /usr/include/x86_64-linux-gnu:
	`export C_INCLUDE_PATH=/usr/include/globus/`

```
cd B2STAGE-GridFTP
cmake3 .

cmake
ERROR:
CMake Error at CMakeLists.txt:44 (find_package):
  Could not find a package configuration file provided by "IRODS" (requested
  version 4.2.1) with any of the following names:

    IRODSConfig.cmake
    irods-config.cmake
```
—> `yum -y install irods-devel`

```
make
ERROR:
	make[2]: /opt/irods-externals/clang3.8-0/bin/clang: Command not found
```
—> `sudo yum install irods-externals-clang3.8-0.x86_64`